### PR TITLE
Clean up cg api key in tests & Add txSemaphore

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@ajna-finance/sdk": "^0.4.7",
+    "@ethersproject/abstract-provider": "^5.7.0",
     "@inquirer/prompts": "^7.2.3",
     "@uniswap/sdk-core": "^7.5.0",
     "@uniswap/v3-core": "^1.0.1",

--- a/src/collect-bond.ts
+++ b/src/collect-bond.ts
@@ -1,4 +1,4 @@
-import { FungiblePool, Signer } from '@ajna-finance/sdk';
+import { FungiblePool, Signer, WrappedTransaction } from '@ajna-finance/sdk';
 import { BigNumber } from 'ethers';
 import { KeeperConfig, PoolConfig } from './config-types';
 import { logger } from './logging';

--- a/src/collect-lp.ts
+++ b/src/collect-lp.ts
@@ -17,6 +17,7 @@ import {
 import { BigNumber } from 'ethers';
 import { decimaledToWei, RequireFields, weiToDecimaled } from './utils';
 import { logger } from './logging';
+import { txSemaphore } from './tx-semaphore';
 
 /**
  * Collects lp rewarded from BucketTakes without collecting the user's deposits or loans.
@@ -110,11 +111,13 @@ export class LpCollector {
             logger.debug(
               `Collecting LP reward as quote. pool: ${this.pool.name}`
             );
-            const withdrawQuoteTx = await bucket.removeQuoteToken(
-              this.signer,
-              quoteToWithdraw
-            );
-            await withdrawQuoteTx.verifyAndSubmit();
+            await txSemaphore.waitForTx(async () => {
+              const withdrawQuoteTx = await bucket.removeQuoteToken(
+                this.signer,
+                quoteToWithdraw
+              );
+              await withdrawQuoteTx.verifyAndSubmit();
+            }, this.signer);
             logger.info(
               `Collected LP reward as quote. pool: ${this.pool.name}, amount: ${weiToDecimaled(quoteToWithdraw)}`
             );
@@ -140,11 +143,13 @@ export class LpCollector {
             logger.debug(
               `Collecting LP reward as collateral. pool ${this.pool.name}`
             );
-            const withdrawCollateralTx = await bucket.removeQuoteToken(
-              this.signer,
-              collateralToWithdraw
-            );
-            await withdrawCollateralTx.verifyAndSubmit();
+            await txSemaphore.waitForTx(async () => {
+              const withdrawCollateralTx = await bucket.removeQuoteToken(
+                this.signer,
+                collateralToWithdraw
+              );
+              await withdrawCollateralTx.verifyAndSubmit();
+            }, this.signer);
             logger.info(
               `Collected LP reward as collateral. pool: ${this.pool.name}, token: ${this.pool.collateralSymbol}, amount: ${weiToDecimaled(collateralToWithdraw)}`
             );

--- a/src/collect-lp.ts
+++ b/src/collect-lp.ts
@@ -204,6 +204,9 @@ export class LpCollector {
     const bucketIndex = parseInt(index.toString());
     const prevReward = this.lpMap.get(bucketIndex) ?? BigNumber.from('0');
     const sumReward = prevReward.add(rewardLp);
+    logger.info(
+      `Received LP Rewards in pool: ${this.pool.name}, bucketIndex: ${index}, rewardLp: ${rewardLp}`
+    );
     this.lpMap.set(bucketIndex, sumReward);
   }
 

--- a/src/integration-tests/collect-bond.test.ts
+++ b/src/integration-tests/collect-bond.test.ts
@@ -92,9 +92,7 @@ describe('collectBondFromPool', () => {
       config: {
         dryRun: false,
         subgraphUrl: '',
-        pricing: {
-          coinGeckoApiKey: '',
-        },
+        coinGeckoApiKey: '',
         delayBetweenActions: 0,
       },
     });
@@ -116,9 +114,7 @@ describe('collectBondFromPool', () => {
       config: {
         dryRun: false,
         subgraphUrl: '',
-        pricing: {
-          coinGeckoApiKey: '',
-        },
+        coinGeckoApiKey: '',
         delayBetweenActions: 0,
       },
     });

--- a/src/integration-tests/collect-lp.test.ts
+++ b/src/integration-tests/collect-lp.test.ts
@@ -21,7 +21,7 @@ import { handleKicks } from '../kick';
 import { handleArbTakes } from '../take';
 import { LpCollector } from '../collect-lp';
 import { BigNumber, Wallet } from 'ethers';
-import { waitForConditionToBeTrue } from './test-utils';
+import { waitForConditionToBeTrue } from '../utils';
 import { getBalanceOfErc20 } from '../erc20';
 
 const setup = async () => {

--- a/src/integration-tests/collect-lp.test.ts
+++ b/src/integration-tests/collect-lp.test.ts
@@ -55,9 +55,7 @@ const setup = async () => {
     config: {
       dryRun: false,
       subgraphUrl: '',
-      pricing: {
-        coinGeckoApiKey: '',
-      },
+      coinGeckoApiKey: '',
       delayBetweenActions: 0,
     },
   });

--- a/src/integration-tests/provider.test.ts
+++ b/src/integration-tests/provider.test.ts
@@ -5,7 +5,7 @@ import { decimaledToWei, weiToDecimaled } from '../utils';
 import 'dotenv';
 import { JsonRpcProvider } from '../provider';
 
-describe.only('JsonRpcProvider', () => {
+describe('JsonRpcProvider', () => {
   beforeEach(async () => {
     await resetHardhat();
   });

--- a/src/integration-tests/take.test.ts
+++ b/src/integration-tests/take.test.ts
@@ -49,9 +49,7 @@ const setup = async () => {
       poolConfig: MAINNET_CONFIG.SOL_WETH_POOL.poolConfig,
       config: {
         subgraphUrl: '',
-        pricing: {
-          coinGeckoApiKey: '',
-        },
+        coinGeckoApiKey: '',
       },
     })
   );

--- a/src/integration-tests/test-utils.ts
+++ b/src/integration-tests/test-utils.ts
@@ -47,12 +47,3 @@ export const increaseTime = async (seconds: number) => {
   await mine();
   return await latestBlockTimestamp();
 };
-
-export const waitForConditionToBeTrue = async (
-  fn: () => Promise<boolean>,
-  pollingTime: number = 0.2
-) => {
-  while (!(await fn())) {
-    await delay(pollingTime);
-  }
-};

--- a/src/kick.ts
+++ b/src/kick.ts
@@ -222,7 +222,7 @@ export async function kick({ pool, signer, config, loanToKick }: KickParams) {
 
     if (!bondApproved) {
       logger.info(
-        `Skipping kick of loan due to insufficient balance. pool: ${pool.name}, borrower: ${loanToKick.borrower}, bond: ${weiToDecimaled(liquidationBond)}`
+        `Failed to approve sufficient bond. Skipping kick of loan. pool: ${pool.name}, borrower: ${loanToKick.borrower}, bond: ${weiToDecimaled(liquidationBond)}`
       );
       return;
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -131,7 +131,6 @@ async function collectLpRewardsLoop({
 
   while (true) {
     for (const poolConfig of poolsWithCollectLpSettings) {
-      const pool = poolMap.get(poolConfig.address)!;
       const collector = lpCollectors.get(poolConfig.address)!;
       await collector.collectLpRewards();
       await delay(config.delayBetweenActions);

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,13 +59,17 @@ async function kickPoolsLoop({ poolMap, config, signer }: KeepPoolParams) {
   while (true) {
     for (const poolConfig of poolsWithKickSettings) {
       const pool = poolMap.get(poolConfig.address)!;
-      await handleKicks({
-        pool,
-        poolConfig,
-        signer,
-        config,
-      });
-      await delay(config.delayBetweenActions);
+      try {
+        await handleKicks({
+          pool,
+          poolConfig,
+          signer,
+          config,
+        });
+        await delay(config.delayBetweenActions);
+      } catch (error) {
+        logger.error(`Failed to handle kicks for pool: ${pool.name}.`, error);
+      }
     }
     await delay(config.delayBetweenRuns);
   }
@@ -82,13 +86,20 @@ async function arbTakePoolsLoop({ poolMap, config, signer }: KeepPoolParams) {
   while (true) {
     for (const poolConfig of poolsWithTakeSettings) {
       const pool = poolMap.get(poolConfig.address)!;
-      await handleArbTakes({
-        pool,
-        poolConfig,
-        signer,
-        config,
-      });
-      await delay(config.delayBetweenActions);
+      try {
+        await handleArbTakes({
+          pool,
+          poolConfig,
+          signer,
+          config,
+        });
+        await delay(config.delayBetweenActions);
+      } catch (error) {
+        logger.error(
+          `Failed to handle arb take for pool: ${pool.name}.`,
+          error
+        );
+      }
     }
     await delay(config.delayBetweenRuns);
   }
@@ -107,8 +118,12 @@ async function collectBondLoop({ poolMap, config, signer }: KeepPoolParams) {
   while (true) {
     for (const poolConfig of poolsWithCollectBondSettings) {
       const pool = poolMap.get(poolConfig.address)!;
-      await collectBondFromPool({ pool, signer, config });
-      await delay(config.delayBetweenActions);
+      try {
+        await collectBondFromPool({ pool, signer, config });
+        await delay(config.delayBetweenActions);
+      } catch (error) {
+        logger.error(`Failed to collect bond from pool: ${pool.name}.`, error);
+      }
     }
     await delay(config.delayBetweenRuns);
   }
@@ -132,8 +147,16 @@ async function collectLpRewardsLoop({
   while (true) {
     for (const poolConfig of poolsWithCollectLpSettings) {
       const collector = lpCollectors.get(poolConfig.address)!;
-      await collector.collectLpRewards();
-      await delay(config.delayBetweenActions);
+      try {
+        await collector.collectLpRewards();
+        await delay(config.delayBetweenActions);
+      } catch (error) {
+        const pool = poolMap.get(poolConfig.address)!;
+        logger.error(
+          `Failed to collect LP reward from pool: ${pool.name}.`,
+          error
+        );
+      }
     }
     await delay(config.delayBetweenRuns);
   }

--- a/src/take.ts
+++ b/src/take.ts
@@ -18,14 +18,19 @@ export async function handleArbTakes({
   poolConfig,
   config,
 }: HandleArbParams) {
-  const liquidationsToArbTake = await getLiquidationsToArbTake({
+  let liquidationsToArbTake = await getLiquidationsToArbTake({
     pool,
     poolConfig,
     config,
   });
-
   for (const liquidation of liquidationsToArbTake) {
-    await arbTakeLiquidation({ pool, poolConfig, signer, liquidation, config });
+    await arbTakeLiquidation({
+      pool,
+      poolConfig,
+      signer,
+      liquidation,
+      config,
+    });
     await delay(config.delayBetweenActions);
   }
 }

--- a/src/tx-semaphore.ts
+++ b/src/tx-semaphore.ts
@@ -1,0 +1,54 @@
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
+import { Signer } from 'ethers';
+import { waitForConditionToBeTrue } from './utils';
+
+/** Once a transaction is built, it must be sent and received by the block chain with a before the next transaction can be sent or received. This class handles that process. */
+class TransactionSemaphore {
+  private lastPromise: Promise<any> = new Promise((resolve) => resolve(null));
+
+  public async waitForTx<T>(buildAndSendTx: () => Promise<T>, signer: Signer) {
+    const currPromise = callAfterBlocker(
+      this.lastPromise,
+      buildAndSendTx,
+      signer
+    );
+    this.lastPromise = currPromise;
+    const { result, error } = await currPromise;
+    if (error) {
+      throw error;
+    } else {
+      return result;
+    }
+  }
+}
+
+/** Call buildAndSendTx after blockingPromise has resolved. Resolves the result of buildAndSendTx. */
+async function callAfterBlocker<T>(
+  blockingPromise: Promise<any>,
+  buildAndSendTx: () => Promise<T>,
+  signer: Signer
+): Promise<{ result: T | undefined; error: unknown }> {
+  await blockingPromise;
+  let result: T | undefined;
+  try {
+    const txCount = await signer.getTransactionCount();
+    result = await buildAndSendTx();
+
+    // Wait for transactionCount to increase to avoid nonce errors.
+    await waitForConditionToBeTrue(
+      async () => {
+        const newTxCount = await signer.getTransactionCount();
+        return newTxCount > txCount;
+      },
+      0.2,
+      20
+    );
+  } catch (error) {
+    return { result, error };
+  }
+  return { result, error: null };
+}
+
+const txSemaphore = new TransactionSemaphore();
+
+export { txSemaphore };

--- a/src/unit-tests/tx-semaphore.test.ts
+++ b/src/unit-tests/tx-semaphore.test.ts
@@ -1,0 +1,91 @@
+import { expect } from 'chai';
+import { getProvider } from '../integration-tests/test-utils';
+import { txSemaphore } from '../tx-semaphore';
+import { delay } from '../utils';
+import sinon from 'sinon';
+
+let txCount = 0;
+const mockGetTransactionCount = async (...args: any) => {
+  return txCount++;
+};
+
+describe('TransactionSemaphore', () => {
+  const provider = getProvider();
+  const signer = provider.getSigner();
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('Returns result of inner function', async () => {
+    sinon
+      .stub(signer, 'getTransactionCount')
+      .callsFake(mockGetTransactionCount);
+    const result = await txSemaphore.waitForTx(async () => {
+      await delay(1);
+      return 100;
+    }, signer);
+
+    expect(result).equals(100);
+  });
+
+  it('Performs the actions in order', async () => {
+    sinon
+      .stub(signer, 'getTransactionCount')
+      .callsFake(mockGetTransactionCount);
+    let actionCount = 0;
+    const prom1 = txSemaphore.waitForTx(async () => {
+      await delay(0.5);
+      await delay(0.1);
+      return actionCount++;
+    }, signer);
+    const prom2 = txSemaphore.waitForTx(async () => {
+      await delay(0.1);
+      return actionCount++;
+    }, signer);
+    const prom3 = txSemaphore.waitForTx(async () => {
+      return actionCount++;
+    }, signer);
+    const [result1, result2, result3] = await Promise.all([
+      prom1,
+      prom2,
+      prom3,
+    ]);
+    expect(result1).equals(0);
+    expect(result2).equals(1);
+    expect(result3).equals(2);
+  });
+
+  it('Throws errors', async () => {
+    sinon
+      .stub(signer, 'getTransactionCount')
+      .callsFake(mockGetTransactionCount);
+
+    const failPromise = txSemaphore.waitForTx(async () => {
+      throw new Error('Test error');
+    }, signer);
+    expect(failPromise).to.be.rejectedWith('Test error');
+  });
+
+  it('Waits for getTransactionCount to increase', async function () {
+    this.timeout(40000);
+    let manualTxCount = 0;
+    const manualTransactionCount = async (...args: any) => {
+      return manualTxCount;
+    };
+    sinon.stub(signer, 'getTransactionCount').callsFake(manualTransactionCount);
+    const expectedResult = 'Hello world';
+    const prom = txSemaphore.waitForTx(async () => {
+      return expectedResult;
+    }, signer);
+    const resolvesInSeconds = async (seconds: number) => {
+      await delay(seconds);
+      return undefined;
+    };
+    const raceResult1 = await Promise.race([prom, resolvesInSeconds(1)]);
+    expect(raceResult1).equals(undefined);
+    manualTxCount = 1;
+    const raceResult2 = await Promise.race([prom, resolvesInSeconds(1)]);
+    expect(raceResult2).equals(expectedResult);
+  });
+});

--- a/src/unit-tests/utils.test.ts
+++ b/src/unit-tests/utils.test.ts
@@ -7,6 +7,7 @@ import {
   decimaledToWei,
   weiToDecimaled,
   tokenChangeDecimals,
+  waitForConditionToBeTrue,
 } from '../utils';
 
 const mockAddress = '0x123456abcabc123456abcabcd123456abcdabcd1';
@@ -161,4 +162,48 @@ describe('tokenChangeDecimals', () => {
   testConvertDecimals('1000000', 6, 18, '1000000000000000000');
   testConvertDecimals('1000000000000000000', 18, 6, '1000000');
   testConvertDecimals('1000000000000000000', 18, 18, '1000000000000000000');
+});
+
+describe('waitForConditionToBeTrue', () => {
+  it('Waits for condition to be true', async function () {
+    this.timeout(10000);
+    const waitTimeSeconds = 3;
+    const startTime = Date.now();
+    await waitForConditionToBeTrue(async () => {
+      const elapsedTimeSeconds = (Date.now() - startTime) / 1000;
+      return elapsedTimeSeconds > waitTimeSeconds;
+    });
+    const elapsedTimeMs = Date.now() - startTime;
+    expect(elapsedTimeMs).gte(waitTimeSeconds * 1000);
+  });
+
+  it('respects pollingInterval', async function () {
+    this.timeout(10000);
+    const waitTimeSeconds = 3;
+    const startTime = Date.now();
+    let fnCalledCount = 0;
+    await waitForConditionToBeTrue(async () => {
+      fnCalledCount++;
+      const elapsedTimeSeconds = (Date.now() - startTime) / 1000;
+      return elapsedTimeSeconds > waitTimeSeconds;
+    }, 0.1);
+    expect(fnCalledCount).lte(31).and.gte(29);
+  });
+
+  it('times out', async function () {
+    this.timeout(10000);
+    const waitTimeSeconds = 3;
+    const startTime = Date.now();
+    const waitForFn = waitForConditionToBeTrue(
+      async () => {
+        const elapsedTimeSeconds = (Date.now() - startTime) / 1000;
+        return elapsedTimeSeconds > waitTimeSeconds;
+      },
+      0.1,
+      1
+    );
+    expect(waitForFn).to.be.rejectedWith(
+      'Timed out before condition became true.'
+    );
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,15 +134,15 @@ export async function arrayFromAsync<T>(
  */
 export const waitForConditionToBeTrue = async (
   fn: () => Promise<boolean>,
-  pollingInterval: number = 0.2,
-  timeout: number = 40
+  pollingIntervalSeconds: number = 0.2,
+  timeoutSeconds: number = 40
 ) => {
   const startTime = Date.now();
   while (!(await fn())) {
     const timeWaited = (Date.now() - startTime) / 1000;
-    if (timeWaited > timeout) {
+    if (timeWaited > timeoutSeconds) {
       throw new Error('Timed out before condition became true.');
     }
-    await delay(pollingInterval);
+    await delay(pollingIntervalSeconds);
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -125,3 +125,24 @@ export async function arrayFromAsync<T>(
   }
   return result;
 }
+
+/**
+ *
+ * @param fn Function which should resolve a true value eventually.
+ * @param pollingInterval Time between function checks in seconds.
+ * @param timeout Time until timeout in seconds.
+ */
+export const waitForConditionToBeTrue = async (
+  fn: () => Promise<boolean>,
+  pollingInterval: number = 0.2,
+  timeout: number = 40
+) => {
+  const startTime = Date.now();
+  while (!(await fn())) {
+    const timeWaited = (Date.now() - startTime) / 1000;
+    if (timeWaited > timeout) {
+      throw new Error('Timed out before condition became true.');
+    }
+    await delay(pollingInterval);
+  }
+};


### PR DESCRIPTION
Clean up CG API key
Add TransactionSemaphore to prevent nonce errors when sending multiple transactions quickly.
Wrap handlers in try-catch to prevent crash of bot.