### PR TITLE
Redeem strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ tokenAddresses: {
 ```
 
 `pools.collectLpReward.rewardAction`:
-LP in buckets can be reedemed for quote token and/or collateral, depending on what the bucket holds at time of redemption. `redeemFirst` controls the redemption strategy, favoring either quote token (most situations) or collateral (useful in shorting pools).  To defer redeeming the second token, it's `minAmount` can be set to a sufficiently high value that manually swapping tokens on an exchange becomes practical.
+LP in buckets can be reedemed for quote token and/or collateral, depending on what the bucket holds at time of redemption. `redeemFirst` controls the redemption strategy, favoring either quote token (most situations) or collateral (useful in shorting pools). To defer redeeming the second token, it's `minAmount` can be set to a sufficiently high value that manually swapping tokens on an exchange becomes practical.
 
-Separate reward actions may be assigned to quote token and collateral, allowing tokens to be swapped out as desired.  For pools where you want to swap rewards with 1inch, set `useOneInch: true` in the `rewardAction`.
-
+Separate reward actions may be assigned to quote token and collateral, allowing tokens to be swapped out as desired. For pools where you want to swap rewards with 1inch, set `useOneInch: true` in the `rewardAction`.
 
 - Example: Volatile-to-volatile pool, swap both tokens for stables
+
 ```
 pools: [
   {
@@ -227,6 +227,7 @@ pools: [
 ```
 
 - Example: Stablecoin pool, swap collateral for quote token
+
 ```
 pools: [
   {
@@ -250,6 +251,7 @@ pools: [
 ```
 
 - Example: Shorting pool, no automated swapping
+
 ```
 pools: [
   {

--- a/README.md
+++ b/README.md
@@ -191,49 +191,79 @@ tokenAddresses: {
 ```
 
 `pools.collectLpReward.rewardAction`:
-For pools where you want to swap rewards with 1inch, set `useOneInch: true` in the `rewardAction`.
+LP in buckets can be reedemed for quote token and/or collateral, depending on what the bucket holds at time of redemption. `redeemFirst` controls the redemption strategy, favoring either quote token (most situations) or collateral (useful in shorting pools).  To defer redeeming the second token, it's `minAmount` can be set to a sufficiently high value that manually swapping tokens on an exchange becomes practical.
 
-- Format:
+Separate reward actions may be assigned to quote token and collateral, allowing tokens to be swapped out as desired.  For pools where you want to swap rewards with 1inch, set `useOneInch: true` in the `rewardAction`.
 
-```
-{
-  name: "Your Pool Name",
-  address: "0xpoolAddress",
-  // Other pool settings...
-  collectLpReward: {
-    redeemAs: "QUOTE", // or "COLLATERAL"
-    minAmount: 0.001,
-    rewardAction: {
-      action: "EXCHANGE",
-      address: "0xtokenAddress", // Token to swap
-      targetToken: "weth",      // Target token (e.g., "weth", "usdc")
-      slippage: 1,             // Slippage percentage (0-100)
-      useOneInch: true         // Set to true for 1inch
-    }
-  }
-}
-```
 
-- Example:
-
+- Example: Volatile-to-volatile pool, swap both tokens for stables
 ```
 pools: [
   {
     name: "wstETH / WETH",
     address: "0x63a366fc5976ff72999c89f69366f388b7d233e8",
+    ...
     collectLpReward: {
-      redeemAs: "QUOTE",
-      minAmount: 0.001,
-      rewardAction: {
+      redeemFirst: TokenToCollect.QUOTE, // favor redeeming LP for WETH before redeeming for wstETH
+      minAmountQuote: 0.001,             // don't redeem LP for dust amount of WETH
+      minAmountCollateral: 0.005,        // ensure we're redeeming enough to cover swapping fees
+      rewardActionQuote: {
         action: "EXCHANGE",
-        address: "0xaddressOfWstETH",
-        targetToken: "weth",
-        slippage: 1,
-        useOneInch: true
+        address: "0x4200000000000000000000000000000000000006", // Token to swap (WETH)
+        targetToken: "DAI",                                    // Desired token
+        slippage: 1,                                           // Slippage percentage (0-100)
+        useOneInch: true                                       // Set to true for 1inch
       }
-    }
+      rewardActionCollateral: {
+        action: "EXCHANGE",
+        address: "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452", // Token to swap (wstETH)
+        targetToken: "DAI",                                    // Desired token
+        slippage: 1,                                           // Slippage percentage (0-100)
+        useOneInch: true                                       // Set to true for 1inch
+      },
+    },
   }
 ],
+```
+
+- Example: Stablecoin pool, swap collateral for quote token
+```
+pools: [
+  {
+      name: 'savUSD / USDC',
+      address: '0x936e0fdec18d4dc5055b3e091fa063bc75d6215c',
+      ...
+      collectLpReward: {
+        redeemFirst: TokenToCollect.QUOTE,
+        minAmountQuote: 0.01,       // don't redeem LP for less than a penny
+        minAmountCollateral: 0.05,  // don't redeem LP for less than what it may cost to swap collateral for USDC
+        rewardActionCollateral: {
+          action: RewardActionLabel.EXCHANGE,
+          address: "0x06d47F3fb376649c3A9Dafe069B3D6E35572219E", // Token to swap (savUSD)
+          targetToken: "usdc",                                   // Target token (USDC)
+          slippage: 1,                                           // Slippage percentage (0-100)
+          useOneInch: true                                       // Set to true for 1inch
+        },
+      },
+  }
+],
+```
+
+- Example: Shorting pool, no automated swapping
+```
+pools: [
+  {
+    name: "DAI / wSOL",
+    address: "0x63a366fc5976ff72999c89f69366f388b7d233e8",
+    ...
+    collectLpReward: {
+      redeemFirst: TokenToCollect.COLLATERAL, // favor redeeming LP for DAI
+      minAmountQuote: 200,                    // don't exchange LP for an amount of wSOL not worth manually swapping
+      minAmountCollateral: 0.15,              // don't redeem LP for less than transaction fees
+    },
+  }
+],
+
 ```
 
 ##### Notes
@@ -293,7 +323,7 @@ For pools where you want to swap rewards with Uniswap V3, set `useOneInch: false
   address: "0xpoolAddress",
   // Other pool settings...
   collectLpReward: {
-    redeemAs: "QUOTE", // or "COLLATERAL"
+    redeemFirst: "QUOTE", // or "COLLATERAL"
     minAmount: 0.001,
     rewardAction: {
       action: "EXCHANGE",
@@ -315,7 +345,7 @@ pools: [
     name: "WETH / USDC",
     address: "0x0b17159f2486f669a1f930926638008e2ccb4287",
     collectLpReward: {
-      redeemAs: "COLLATERAL",
+      redeemFirst: "COLLATERAL",
       minAmount: 0.001,
       rewardAction: {
         action: "EXCHANGE",

--- a/example-config.ts
+++ b/example-config.ts
@@ -122,17 +122,17 @@ const config: KeeperConfig = {
       name: 'savUSD / USDC',
       address: '0x936e0fdec18d4dc5055b3e091fa063bc75d6215c',
       price: {
-          source: PriceOriginSource.FIXED,
-          value: 1.01,
-        },
-        kick: {
-          minDebt: 0.07,
-          priceFactor: 0.99,
-        },
+        source: PriceOriginSource.FIXED,
+        value: 1.01,
+      },
+      kick: {
+        minDebt: 0.07,
+        priceFactor: 0.99,
+      },
       take: {
-          minCollateral: 0.07,
-          priceFactor: 0.98,
-        },
+        minCollateral: 0.07,
+        priceFactor: 0.98,
+      },
       collectBond: true,
       collectLpReward: {
         redeemFirst: TokenToCollect.QUOTE,
@@ -140,10 +140,10 @@ const config: KeeperConfig = {
         minAmountCollateral: 0.05,
         rewardActionCollateral: {
           action: RewardActionLabel.EXCHANGE,
-          address: "0x06d47F3fb376649c3A9Dafe069B3D6E35572219E",
-          targetToken: "usdc",
+          address: '0x06d47F3fb376649c3A9Dafe069B3D6E35572219E',
+          targetToken: 'usdc',
           slippage: 1,
-          useOneInch: true
+          useOneInch: true,
         },
       },
     },

--- a/example-config.ts
+++ b/example-config.ts
@@ -57,9 +57,10 @@ const config: KeeperConfig = {
       },
       collectBond: true,
       collectLpReward: {
-        redeemAs: TokenToCollect.QUOTE,
-        minAmount: 0.001,
-        rewardAction: {
+        redeemFirst: TokenToCollect.QUOTE,
+        minAmountQuote: 0.001,
+        minAmountCollateral: 1000,
+        rewardActionQuote: {
           action: RewardActionLabel.EXCHANGE,
           address: '0xaddressOfWstETH',
           targetToken: 'weth',
@@ -86,9 +87,10 @@ const config: KeeperConfig = {
       },
       collectBond: true,
       collectLpReward: {
-        redeemAs: TokenToCollect.COLLATERAL,
-        minAmount: 0.001,
-        rewardAction: {
+        redeemFirst: TokenToCollect.COLLATERAL,
+        minAmountQuote: 1000,
+        minAmountCollateral: 0.001,
+        rewardActionCollateral: {
           action: RewardActionLabel.TRANSFER,
           to: '0x0000000000000000000000000000000000000000',
         },
@@ -111,8 +113,38 @@ const config: KeeperConfig = {
       },
       collectBond: true,
       collectLpReward: {
-        redeemAs: TokenToCollect.QUOTE,
-        minAmount: 0.001,
+        redeemFirst: TokenToCollect.QUOTE,
+        minAmountQuote: 0.001,
+        minAmountCollateral: 100,
+      },
+    },
+    {
+      name: 'savUSD / USDC',
+      address: '0x936e0fdec18d4dc5055b3e091fa063bc75d6215c',
+      price: {
+          source: PriceOriginSource.FIXED,
+          value: 1.01,
+        },
+        kick: {
+          minDebt: 0.07,
+          priceFactor: 0.99,
+        },
+      take: {
+          minCollateral: 0.07,
+          priceFactor: 0.98,
+        },
+      collectBond: true,
+      collectLpReward: {
+        redeemFirst: TokenToCollect.QUOTE,
+        minAmountQuote: 0.001,
+        minAmountCollateral: 0.05,
+        rewardActionCollateral: {
+          action: RewardActionLabel.EXCHANGE,
+          address: "0x06d47F3fb376649c3A9Dafe069B3D6E35572219E",
+          targetToken: "usdc",
+          slippage: 1,
+          useOneInch: true
+        },
       },
     },
   ],

--- a/src/collect-lp.ts
+++ b/src/collect-lp.ts
@@ -147,7 +147,7 @@ export class LpCollector {
         );
       }
 
-      // Otherwise, default to redeeming quote token first
+    // Otherwise, default to redeeming quote token first
     } else {
       const quoteToWithdraw = min(depositRedeemable, deposit);
       if (quoteToWithdraw.gt(decimaledToWei(minAmountQuote))) {

--- a/src/config-types.ts
+++ b/src/config-types.ts
@@ -129,12 +129,14 @@ export interface ExchangeReward {
 export type RewardAction = TransferReward | ExchangeReward;
 
 interface CollectLpRewardSettings {
-  /** Wether to redeem LP as Quote or Collateral. */
-  redeemAs: TokenToCollect;
+  /** Wether to redeem LP as Quote or Collateral first. If unset will default to Quote first. */
+  redeemFirst?: TokenToCollect;
   /** Minimum amount of token to collect. */
-  minAmount: number;
+  minAmountQuote: number;
+  minAmountCollateral: number;
   /** What to do with Collected LP Rewards. If unset will leave rewards in wallet. */
-  rewardAction?: RewardAction;
+  rewardActionQuote?: RewardAction;
+  rewardActionCollateral?: RewardAction;
 }
 
 export interface PoolConfig {

--- a/src/integration-tests/collect-lp.test.ts
+++ b/src/integration-tests/collect-lp.test.ts
@@ -83,8 +83,9 @@ describe('LpCollector subscription', () => {
       signer,
       {
         collectLpReward: {
-          redeemAs: TokenToCollect.QUOTE,
-          minAmount: 0,
+          redeemFirst: TokenToCollect.QUOTE,
+          minAmountQuote: 0,
+          minAmountCollateral: 0,
         },
       },
       {},
@@ -130,8 +131,9 @@ describe('LpCollector subscription', () => {
       noActionSigner,
       {
         collectLpReward: {
-          redeemAs: TokenToCollect.QUOTE,
-          minAmount: 0,
+          redeemFirst: TokenToCollect.QUOTE,
+          minAmountQuote: 0,
+          minAmountCollateral: 0,
         },
       },
       {},
@@ -179,8 +181,9 @@ describe('LpCollector subscription', () => {
       kickerSigner,
       {
         collectLpReward: {
-          redeemAs: TokenToCollect.QUOTE,
-          minAmount: 0,
+          redeemFirst: TokenToCollect.QUOTE,
+          minAmountQuote: 0,
+          minAmountCollateral: 0,
         },
       },
       {},
@@ -238,8 +241,9 @@ describe('LpCollector collections', () => {
       signer,
       {
         collectLpReward: {
-          redeemAs: TokenToCollect.QUOTE,
-          minAmount: 0,
+          redeemFirst: TokenToCollect.QUOTE,
+          minAmountQuote: 0,
+          minAmountCollateral: 0,
         },
       },
       {},

--- a/src/integration-tests/collect-lp.test.ts
+++ b/src/integration-tests/collect-lp.test.ts
@@ -229,6 +229,7 @@ describe('LpCollector collections', () => {
     await resetHardhat();
   });
 
+  // TODO: Refactor this into two tests, one redeeming quote first and another redeeming collateral first
   it('Collects tracked rewards', async () => {
     const pool = await setup();
     const signer = await impersonateSigner(

--- a/src/kick.ts
+++ b/src/kick.ts
@@ -84,7 +84,7 @@ export async function* getLoansToKick({
     const borrower = borrowersSortedByBond[i];
     const [poolPrices, loanDetails] = await Promise.all([
       pool.getPrices(),
-      pool.getLoan(borrower)
+      pool.getLoan(borrower),
     ]);
     const { lup, hpb } = poolPrices;
     const { thresholdPrice, liquidationBond, debt, neutralPrice } = loanDetails;
@@ -159,7 +159,7 @@ async function approveBalanceForLoanToKick({
   const { liquidationBond, estimatedRemainingBond } = loanToKick;
   const [balanceNative, quoteDecimals] = await Promise.all([
     getBalanceOfErc20(signer, pool.quoteAddress),
-    getDecimalsErc20(signer, pool.quoteAddress)
+    getDecimalsErc20(signer, pool.quoteAddress),
   ]);
   const balanceWad = tokenChangeDecimals(balanceNative, quoteDecimals);
   if (balanceWad < liquidationBond) {

--- a/src/reward-action-tracker.ts
+++ b/src/reward-action-tracker.ts
@@ -119,13 +119,20 @@ export class RewardActionTracker {
         case RewardActionLabel.EXCHANGE:
           const pool = this.config.pools.find(
             (p) =>
-              p.collectLpReward?.rewardAction?.action ===
-                RewardActionLabel.EXCHANGE &&
-              p.collectLpReward?.rewardAction?.address.toLowerCase() ===
-                token.toLowerCase()
-          );
-          const tokenConfig = pool?.collectLpReward
-            ?.rewardAction as TokenConfig;
+              (
+                p.collectLpReward?.rewardActionQuote?.action ===
+                  RewardActionLabel.EXCHANGE &&
+                p.collectLpReward?.rewardActionQuote?.address.toLowerCase() ===
+                  token.toLowerCase()
+              ) || (
+                p.collectLpReward?.rewardActionCollateral?.action ===
+                  RewardActionLabel.EXCHANGE &&
+                p.collectLpReward?.rewardActionCollateral?.address.toLowerCase() ===
+                  token.toLowerCase()
+              )
+          )
+
+          const tokenConfig = rewardAction as TokenConfig;
 
           const slippage =
             tokenConfig?.slippage ??

--- a/src/reward-action-tracker.ts
+++ b/src/reward-action-tracker.ts
@@ -5,7 +5,7 @@ import {
   KeeperConfig,
   RewardAction,
   RewardActionLabel,
-  TransferReward
+  TransferReward,
 } from './config-types';
 import { DexRouter } from './dex-router';
 import { getDecimalsErc20, transferErc20 } from './erc20';
@@ -117,21 +117,6 @@ export class RewardActionTracker {
           break;
 
         case RewardActionLabel.EXCHANGE:
-          const pool = this.config.pools.find(
-            (p) =>
-              (
-                p.collectLpReward?.rewardActionQuote?.action ===
-                  RewardActionLabel.EXCHANGE &&
-                p.collectLpReward?.rewardActionQuote?.address.toLowerCase() ===
-                  token.toLowerCase()
-              ) || (
-                p.collectLpReward?.rewardActionCollateral?.action ===
-                  RewardActionLabel.EXCHANGE &&
-                p.collectLpReward?.rewardActionCollateral?.address.toLowerCase() ===
-                  token.toLowerCase()
-              )
-          )
-
           const tokenConfig = rewardAction as TokenConfig;
 
           const slippage =

--- a/src/uniswap.ts
+++ b/src/uniswap.ts
@@ -18,7 +18,14 @@ import {
   Trade,
   Pool as UniswapV3Pool,
 } from '@uniswap/v3-sdk';
-import { BigNumber, Contract, ethers, providers, Signer, constants } from 'ethers';
+import {
+  BigNumber,
+  Contract,
+  ethers,
+  providers,
+  Signer,
+  constants,
+} from 'ethers';
 import ERC20_ABI from './abis/erc20.abi.json';
 import { logger } from './logging';
 import { NonceTracker } from './nonce';

--- a/src/unit-tests/dex-router.test.ts
+++ b/src/unit-tests/dex-router.test.ts
@@ -1,7 +1,14 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
-import { BigNumber, Contract, Signer, ethers, providers, constants } from 'ethers';
+import {
+  BigNumber,
+  Contract,
+  Signer,
+  ethers,
+  providers,
+  constants,
+} from 'ethers';
 import axios from 'axios';
 import { DexRouter } from '../dex-router';
 import { logger } from '../logging';


### PR DESCRIPTION
Current implementation only redeems LP for quote or collateral, ignoring that buckets may be left with both.  This change replaces `redeemAs` with `redeemFirst`, and defaults to redeeming for quote token first.  (Redeeming collateral first only really useful for shorting pools.)  Min amounts and actions are, somewhat inelegantly due to time constraints, separated for quote and collateral.