### PR TITLE
Fix LP token accounting to track actual redeemed LP tokens

### DIFF
--- a/src/collect-lp.ts
+++ b/src/collect-lp.ts
@@ -205,9 +205,6 @@ export class LpCollector {
         // Get LP balance after the transaction
         const { lpBalance: lpBalanceAfter } = await bucket.getPosition(signerAddress);
         
-        // Calculate the actual LP used
-        const actualLpUsed = lpBalanceBefore.sub(lpBalanceAfter);
-        
         logger.info(
           `Collected LP reward as quote. pool: ${this.pool.name}, amount: ${weiToDecimaled(quoteToWithdraw)}`
         );
@@ -221,7 +218,8 @@ export class LpCollector {
         }
         
         // Return the actual LP used
-        return actualLpUsed;
+        return lpBalanceBefore.sub(lpBalanceAfter);
+
       } catch (error) {
         logger.error(
           `Failed to collect LP reward as quote. pool: ${this.pool.name}`,
@@ -262,9 +260,6 @@ export class LpCollector {
         // Get LP balance after the transaction
         const { lpBalance: lpBalanceAfter } = await bucket.getPosition(signerAddress);
         
-        // Calculate the actual LP used
-        const actualLpUsed = lpBalanceBefore.sub(lpBalanceAfter);
-        
         logger.info(
           `Collected LP reward as collateral. pool: ${this.pool.name}, token: ${this.pool.collateralSymbol}, amount: ${weiToDecimaled(collateralToWithdraw)}`
         );
@@ -278,7 +273,8 @@ export class LpCollector {
         }
         
         // Return the actual LP used 
-        return actualLpUsed;
+        return lpBalanceBefore.sub(lpBalanceAfter);
+
       } catch (error) {
         logger.error(
           `Failed to collect LP reward as collateral. pool: ${this.pool.name}`,

--- a/src/collect-lp.ts
+++ b/src/collect-lp.ts
@@ -195,7 +195,19 @@ export class LpCollector {
     } else {
       try {
         logger.debug(`Collecting LP reward as quote. pool: ${this.pool.name}`);
+        
+        // ADDED CODE: Get LP balance before the transaction
+        const signerAddress = await this.signer.getAddress();
+        const { lpBalance: lpBalanceBefore } = await bucket.getPosition(signerAddress);
+        
         await bucketRemoveQuoteToken(bucket, this.signer, quoteToWithdraw);
+        
+        // ADDED CODE: Get LP balance after the transaction
+        const { lpBalance: lpBalanceAfter } = await bucket.getPosition(signerAddress);
+        
+        // ADDED CODE: Calculate the actual LP used
+        const actualLpUsed = lpBalanceBefore.sub(lpBalanceAfter);
+        
         logger.info(
           `Collected LP reward as quote. pool: ${this.pool.name}, amount: ${weiToDecimaled(quoteToWithdraw)}`
         );
@@ -208,8 +220,12 @@ export class LpCollector {
           );
         }
 
-        // FIXME: this calculates how much we LP we tried to redeem, not how much we actually redeemed
-        return wdiv(quoteToWithdraw, exchangeRate);
+        // REMOVED CODE: 
+        // // FIXME: this calculates how much we LP we tried to redeem, not how much we actually redeemed
+        // return wdiv(quoteToWithdraw, exchangeRate);
+        
+        // ADDED CODE: Return the actual LP used instead of calculating it
+        return actualLpUsed;
       } catch (error) {
         logger.error(
           `Failed to collect LP reward as quote. pool: ${this.pool.name}`,
@@ -236,11 +252,23 @@ export class LpCollector {
         logger.debug(
           `Collecting LP reward as collateral. pool ${this.pool.name}`
         );
+        
+        // ADDED CODE: Get LP balance before the transaction
+        const signerAddress = await this.signer.getAddress();
+        const { lpBalance: lpBalanceBefore } = await bucket.getPosition(signerAddress);
+        
         await bucketRemoveCollateralToken(
           bucket,
           this.signer,
           collateralToWithdraw
         );
+        
+        // ADDED CODE: Get LP balance after the transaction
+        const { lpBalance: lpBalanceAfter } = await bucket.getPosition(signerAddress);
+        
+        // ADDED CODE: Calculate the actual LP used
+        const actualLpUsed = lpBalanceBefore.sub(lpBalanceAfter);
+        
         logger.info(
           `Collected LP reward as collateral. pool: ${this.pool.name}, token: ${this.pool.collateralSymbol}, amount: ${weiToDecimaled(collateralToWithdraw)}`
         );
@@ -253,9 +281,13 @@ export class LpCollector {
           );
         }
 
-        const price = indexToPrice(bucketIndex);
-        // FIXME: this calculates how much we LP we tried to redeem, not how much we actually redeemed
-        return wdiv(wdiv(collateralToWithdraw, price), exchangeRate);
+        // REMOVED CODE:
+        // const price = indexToPrice(bucketIndex);
+        // // FIXME: this calculates how much we LP we tried to redeem, not how much we actually redeemed
+        // return wdiv(wdiv(collateralToWithdraw, price), exchangeRate);
+        
+        // ADDED CODE: Return the actual LP used instead of calculating it
+        return actualLpUsed;
       } catch (error) {
         logger.error(
           `Failed to collect LP reward as collateral. pool: ${this.pool.name}`,

--- a/src/collect-lp.ts
+++ b/src/collect-lp.ts
@@ -196,16 +196,16 @@ export class LpCollector {
       try {
         logger.debug(`Collecting LP reward as quote. pool: ${this.pool.name}`);
         
-        // ADDED CODE: Get LP balance before the transaction
+        // Get LP balance before the transaction
         const signerAddress = await this.signer.getAddress();
         const { lpBalance: lpBalanceBefore } = await bucket.getPosition(signerAddress);
         
         await bucketRemoveQuoteToken(bucket, this.signer, quoteToWithdraw);
         
-        // ADDED CODE: Get LP balance after the transaction
+        // Get LP balance after the transaction
         const { lpBalance: lpBalanceAfter } = await bucket.getPosition(signerAddress);
         
-        // ADDED CODE: Calculate the actual LP used
+        // Calculate the actual LP used
         const actualLpUsed = lpBalanceBefore.sub(lpBalanceAfter);
         
         logger.info(
@@ -219,12 +219,8 @@ export class LpCollector {
             quoteToWithdraw
           );
         }
-
-        // REMOVED CODE: 
-        // // FIXME: this calculates how much we LP we tried to redeem, not how much we actually redeemed
-        // return wdiv(quoteToWithdraw, exchangeRate);
         
-        // ADDED CODE: Return the actual LP used instead of calculating it
+        // Return the actual LP used
         return actualLpUsed;
       } catch (error) {
         logger.error(
@@ -253,7 +249,7 @@ export class LpCollector {
           `Collecting LP reward as collateral. pool ${this.pool.name}`
         );
         
-        // ADDED CODE: Get LP balance before the transaction
+        // Get LP balance before the transaction
         const signerAddress = await this.signer.getAddress();
         const { lpBalance: lpBalanceBefore } = await bucket.getPosition(signerAddress);
         
@@ -263,10 +259,10 @@ export class LpCollector {
           collateralToWithdraw
         );
         
-        // ADDED CODE: Get LP balance after the transaction
+        // Get LP balance after the transaction
         const { lpBalance: lpBalanceAfter } = await bucket.getPosition(signerAddress);
         
-        // ADDED CODE: Calculate the actual LP used
+        // Calculate the actual LP used
         const actualLpUsed = lpBalanceBefore.sub(lpBalanceAfter);
         
         logger.info(
@@ -280,13 +276,8 @@ export class LpCollector {
             collateralToWithdraw
           );
         }
-
-        // REMOVED CODE:
-        // const price = indexToPrice(bucketIndex);
-        // // FIXME: this calculates how much we LP we tried to redeem, not how much we actually redeemed
-        // return wdiv(wdiv(collateralToWithdraw, price), exchangeRate);
         
-        // ADDED CODE: Return the actual LP used instead of calculating it
+        // Return the actual LP used 
         return actualLpUsed;
       } catch (error) {
         logger.error(


### PR DESCRIPTION
This PR fixes the issue identified in the FIXME comments in the LpCollector class related to LP token accounting.

## Problem
The code was calculating LP tokens based on the amount requested to be withdrawn rather than the amount actually withdrawn, which could lead to inaccurate LP token tracking.

## Solution
- Modified `redeemQuote` and `redeemCollateral` methods to:
  - Record LP balance before transaction
  - Execute the transaction
  - Record LP balance after transaction
  - Calculate actual LP tokens used by comparing before/after balances

This ensures accurate tracking of LP tokens and prevents potential accounting discrepancies.
